### PR TITLE
include missing step in installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,14 @@ Installation
         'debug_panel',
     )
 
+#. Replace ``debug-toolbar`` middleware with ``debug-panel`` middleware in your ``MIDDLEWARE_CLASSES`` setting:
+
+    MIDDLEWARE_CLASSES = (
+        # 'debug_toolbar.middleware.DebugToolbarMiddleware',
+        'debug_panel.middleware.DebugPanelMiddleware',
+        # ...
+    )
+    
 #. Run ``python manage.py syncdb`` to create the table that store debug information
 
 #. Install the Chrome extension `Django Debug Panel <https://chrome.google.com/webstore/detail/django-debug-panel/nbiajhhibgfgkjegbnflpdccejocmbbn>`_


### PR DESCRIPTION
Alternately, and i actually prefer this, have step #2 just be "Install and configure `Django Debug Panel` with a link to the project's readme.  That way, the missing step (as well as some existing steps) can be found without it being specified here.
