### PR TITLE
Don't fail if localStorage cannot be used.

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -4,7 +4,16 @@ $(function() {
 		$('.split-view-resizer').css('left', width);
 	}
 
-	resizeLeftPanel(localStorage['sidePanelWidth'] || 200);
+	var initial_size = 200;
+	var can_access_localStorage = true;
+	try {
+		initial_size = localStorage['sidePanelWidth'];
+	}
+	catch (ex) {
+		can_access_localStorage = false;
+	}
+
+	resizeLeftPanel(initial_size);
 
 	function resizerDragMove(event) {
 		resizeLeftPanel(event.pageX);
@@ -13,7 +22,8 @@ $(function() {
 
 	function resizerDragEnd(event) {
 		resizeLeftPanel(event.pageX);
-		localStorage['sidePanelWidth'] = event.pageX + 'px';
+		if (can_access_localStorage)
+			localStorage['sidePanelWidth'] = event.pageX + 'px';
 
 		$(document).off('mousemove', resizerDragMove);
 		$(document).off('mouseup', resizerDragEnd);


### PR DESCRIPTION
Previously, if localStorage was not accessible for whatever reason, then
the initialization of the extension would fail. This would leave the
extension with a #request-list that had no width set and no ability to
resize it. This was okay so long as the URLs in the request list were
relatively short but for very long URLs the request list would take more
than the width of the frame that DevTools made available for it and
would thus be unusable.