### PR TITLE
fix sidebar style issue

### DIFF
--- a/panel.css
+++ b/panel.css
@@ -26,6 +26,7 @@ body {
   overflow: auto;
   border-right: 1px solid #ccc;
   display: table-cell;
+  position: fixed;
 }
 
 #debug-toolbar-panel {

--- a/panel.js
+++ b/panel.js
@@ -13,6 +13,7 @@ $(function() {
     function resizeLeftPanel(width) {
         $('#request-list').width(width);
         $('.split-view-resizer').css('left', width);
+        $('.iframe-wrapper').css('padding-left', width);
     }
 
     resizeLeftPanel(localStorage.sidePanelWidth || 200);


### PR DESCRIPTION
Sidebar with requests list always had zero height, probably since chrome updated.
Tested on Chrome 50.0.2661.75.
